### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "go-snippets"
 name = "Go Snippets"
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Ayberk Gezer <ayberkgezer@outlook.com>"]
 description = "Go snippets for Zed IDE. A collection of go snippets to improve your development speed."


### PR DESCRIPTION
Fixes #1 

This in combination with a bump in https://github.com/zed-industries/extensions will fix the issue of snippets not working. The error appeared because the extension-CLI was broken for snippets extensions from the start. 

This was fixed in the meantime. However, a version bump in combination with a bump in the registry is needed for this to work. After merging this, you'll need to open a bump PR against https://github.com/zed-industries/extensions and finally the released version will work 🙂 